### PR TITLE
updating hmac verification function

### DIFF
--- a/src/Services/InstallAndLogin.php
+++ b/src/Services/InstallAndLogin.php
@@ -118,7 +118,7 @@ class InstallAndLogin
         $dataString = array();
 
         foreach ($query as $key => $value) {
-            if (!in_array($key, array('shop', 'timestamp', 'code', 'protocol', 'locale'))) {
+            if ($key == 'hmac') {
                 continue;
             }
             $key = str_replace('=', '%3D', $key);

--- a/src/Services/InstallAndLogin.php
+++ b/src/Services/InstallAndLogin.php
@@ -118,7 +118,7 @@ class InstallAndLogin
         $dataString = array();
 
         foreach ($query as $key => $value) {
-            if ($key == 'hmac') {
+            if ('hmac' == $key) {
                 continue;
             }
             $key = str_replace('=', '%3D', $key);


### PR DESCRIPTION
Shopify recently added session to their request parameters when logging in from the the app page of the shopify admin. So with the old code anything not hardcoded in the old if statement would be getting stripped from the hmac verification and according to we should only be removing the hmac from the request and nothing else included docs for verification. 

https://help.shopify.com/en/api/getting-started/authentication/oauth#verification